### PR TITLE
New features implementation: registration with colors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+chat_history.txt
+client
+server
+server.log
+.vscode/settings.json

--- a/ClientShell.h
+++ b/ClientShell.h
@@ -1,68 +1,73 @@
-#pragma once
+#ifndef CLIENT_SHELL_H
+#define CLIENT_SHELL_H
+
 #include <nlohmann/json.hpp>
 #include "SocketShell.h"
 #include "file_utils.h"
 
 using json = nlohmann::json;
 
-struct ClientShell{
+struct ClientShell {
     std::string login;
     SocketShell clientSocket;
-    ClientShell(std::string login, SocketShell clientSocket):login(login), clientSocket(clientSocket){}
-    operator SocketShell() const{return clientSocket;}
+    ClientShell(std::string login, SocketShell clientSocket) :login(login), clientSocket(clientSocket) {}
+    operator SocketShell() const { return clientSocket; }
 };
 
-namespace global{
+namespace global {
     std::mutex clientMutex;
     std::mutex historyMutex;
     std::vector<ClientShell> clients;
 }
-std::string status(const std::string& __login, const std::string& __password){
-    for(auto client : global::clients){
-        if(client.login == __login){
-            return setColor("already online", {255, 0, 0});
+std::string status(const std::string& __login, const std::string& __password) {
+    for (auto client : global::clients) {
+        if (client.login == __login) {
+            return setColor("already online", { 255, 0, 0 });
         }
     }
     std::ifstream file("users.json");
     json users = json::parse(file);
     file.close();
-    try{
+    try {
         std::string password = users[__login];
-        if(password != __password){
-            return setColor("wrong password", {255, 0, 0});
-        } 
-    }catch(...){return setColor("wrong login", {255, 0, 0});}
+        if (password != __password) {
+            return setColor("wrong password", { 255, 0, 0 });
+        }
+    }
+    catch (...) { return setColor("wrong login", { 255, 0, 0 }); }
     return "accept";
 }
-void preload_history(const SocketShell& __clientSocket){
+void preload_history(const SocketShell& __clientSocket) {
     int counter = 0;
     recv(__clientSocket, &counter, sizeof(counter), 0);
     std::ifstream history("chat_history.txt");
-    if(!history){return;}
+    if (!history) { return; }
     std::string* buf = new std::string[counter];
     int idx = 0;
-    while(!history.eof()){std::getline(history, buf[idx++ % counter]);}
-    for(int i = 0; i < counter; ++i){
-        if(!buf[(idx + i) % counter].empty()){
+    while (!history.eof()) { std::getline(history, buf[idx++ % counter]); }
+    for (int i = 0; i < counter; ++i) {
+        if (!buf[(idx + i) % counter].empty()) {
             sendString(__clientSocket, buf[(idx + i) % counter] + ENDL);
         }
     }
     delete[] buf;
     history.close();
 }
-void sendClients(const std::string& __buf){
+void sendClients(const std::string& __buf) {
     std::cout << __buf << std::endl;
     global::historyMutex.lock();
     std::ofstream history("chat_history.txt", std::ios_base::app);
-    if(history.tellp() != 0){
+    if (history.tellp() != 0) {
         history << std::endl;
     }
     history << __buf;
     history.close();
     global::historyMutex.unlock();
     global::clientMutex.lock();
-    for(auto client : global::clients){
+    for (auto client : global::clients) {
         sendString(client, __buf + ENDL);
     }
     global::clientMutex.unlock();
 }
+
+#endif // !CLIENT_SHELL_H

--- a/ClientShell.h
+++ b/ClientShell.h
@@ -18,6 +18,35 @@ namespace global {
     std::mutex clientMutex;
     std::mutex historyMutex;
     std::vector<ClientShell> clients;
+    std::map<std::string, std::vector<size_t>> colors = {
+        {"red", {255, 0, 0}},
+        {"orange", {255, 165, 0}},
+        {"yellow", {255, 255, 0}},
+        {"green", {0, 255, 0}},
+        {"bright pink", {255, 20, 147}},
+        {"cyan", {0, 255, 255}},
+        {"magenta", {255, 0, 255}}
+    };
+    std::vector<bool> assigned_colors = { false, false, false, false, false, false, false };
+}
+void initAssignedColorsWithDBFile() {
+    std::ifstream file("users.json");
+    if (!file) {
+        std::cerr << "Cannot open database file users.json" << std::endl;
+        return;
+    }
+    json users = json::parse(file);
+    file.close();
+    auto colors_it = global::colors.begin();
+    for (auto user : users) {
+        std::string color = user["color"];
+        for (auto color_it = global::colors.begin(); color_it != global::colors.end(); ++color_it) {
+            if (color_it->first == color) {
+                global::assigned_colors[std::distance(global::colors.begin(), color_it)] = true;
+                break;
+            }
+        }
+    }
 }
 std::string status(const std::string& __login, const std::string& __password) {
     for (auto client : global::clients) {
@@ -29,7 +58,7 @@ std::string status(const std::string& __login, const std::string& __password) {
     json users = json::parse(file);
     file.close();
     try {
-        std::string password = users[__login];
+        std::string password = users[__login]["password"];
         if (password != __password) {
             return setColor("wrong password", { 255, 0, 0 });
         }
@@ -68,6 +97,67 @@ void sendClients(const std::string& __buf) {
         sendString(client, __buf + ENDL);
     }
     global::clientMutex.unlock();
+}
+std::string registerUser(const std::string& __login, const std::string& __password) {
+    // ADD USER TO DATABASE
+    // read database
+    std::ifstream file("users.json");
+    if (!file) {
+        std::cerr << "Cannot open database file users.json" << std::endl;
+        return "Cannot open database file users.json";
+    }
+    json users = json::parse(file);
+    file.close();
+
+    // check if user already exists
+    if (users.contains(__login)) {
+        return "User already exists";
+    }
+
+    // check if all colors are used
+    size_t color_counter = 0;
+    for (auto color : global::assigned_colors) {
+        if (color) {
+            ++color_counter;
+        }
+    }
+    if (color_counter == global::assigned_colors.size()) {
+        return "All colors are used";
+    }
+    // get random color index
+    size_t colors_num = global::assigned_colors.size();
+    std::srand(std::time(nullptr));
+    // check if color is already used
+    size_t color_idx = std::rand() % colors_num;
+    while (global::assigned_colors[color_idx]) {
+        color_idx = std::rand() % colors_num;
+    }
+
+    // get corresponding color
+    size_t idx = 0;
+    for (auto color : global::colors) {
+        if (idx == color_idx) {
+            users[__login] = {
+                {"password", __password},
+                {"color", color.first}
+            };
+            break;
+        }
+        ++idx;
+    }
+
+    // update colors
+    global::assigned_colors[color_idx] = true;
+
+    // write to file
+    std::ofstream file_out("users.json");
+    if (!file_out) {
+        std::cerr << "Cannot open database file users.json" << std::endl;
+        return "Cannot open database file users.json";
+    }
+    file_out << users.dump(4); // 4 spaces
+
+    return "User successfully registered";
 }
 
 #endif // !CLIENT_SHELL_H

--- a/ServerSocket.h
+++ b/ServerSocket.h
@@ -1,43 +1,47 @@
-#pragma once
+#ifndef SERVERSOCKET_H
+#define SERVERSOCKET_H
+
 #include <sys/socket.h>
 #include <netinet/ip.h>
 #include <stdexcept>
 #include <unistd.h>
 
-class ServerSocket{
+class ServerSocket {
     int _port;
     int _serverSocket;
     sockaddr_in _serverAddress;
 public:
-    ServerSocket(int __port = 8080):_port(__port){
+    ServerSocket(int __port = 8080) :_port(__port) {
         _serverSocket = socket(AF_INET, SOCK_STREAM, 0);
         int optval = 1;
         setsockopt(_serverSocket, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval));
         _serverAddress.sin_family = AF_INET;
         _serverAddress.sin_addr.s_addr = INADDR_ANY;
         _serverAddress.sin_port = htons(_port);
-        if(bind(_serverSocket, (sockaddr*)&_serverAddress, sizeof(_serverAddress)) == -1){
+        if (bind(_serverSocket, (sockaddr*)&_serverAddress, sizeof(_serverAddress)) == -1) {
             this->~ServerSocket();
             throw std::runtime_error("[ERROR] FAILED BIND");
         }
-        if(listen(_serverSocket, 64) == -1){
+        if (listen(_serverSocket, 64) == -1) {
             this->~ServerSocket();
             throw std::runtime_error("[ERROR] FAILED LISTEN");
         }
     }
-    int acceptConnection() const{
+    int acceptConnection() const {
         int clientSocket = accept(_serverSocket, nullptr, nullptr);
-        if(clientSocket == -1){
+        if (clientSocket == -1) {
             this->~ServerSocket();
             throw std::runtime_error("[ERROR] FAILED ACCEPT");
         }
         return clientSocket;
     }
-    int port() const {return _port;}
-    ~ServerSocket(){
-        if(_serverSocket != -1){
+    int port() const { return _port; }
+    ~ServerSocket() {
+        if (_serverSocket != -1) {
             close(_serverSocket);
             _serverSocket = -1;
         }
     }
 };
+
+#endif // !SERVERSOCKET_H

--- a/SocketShell.h
+++ b/SocketShell.h
@@ -1,4 +1,6 @@
-#pragma once
+#ifndef _SOCKET_SHELL_H_
+#define _SOCKET_SHELL_H_
+
 #include <sys/socket.h>
 #include <netinet/ip.h>
 #include <arpa/inet.h>
@@ -7,34 +9,36 @@
 
 #define MESSAGE_SIZE 1024
 
-class SocketShell{
+class SocketShell {
     int _clientSocket;
 public:
-    SocketShell(int __clientSocket = -1):_clientSocket(__clientSocket){} 
-    SocketShell(std::string __address, int __port){
+    SocketShell(int __clientSocket = -1) :_clientSocket(__clientSocket) {}
+    SocketShell(std::string __address, int __port) {
         _clientSocket = socket(AF_INET, SOCK_STREAM, 0);
         sockaddr_in serverAddres;
         serverAddres.sin_family = AF_INET;
-        serverAddres.sin_port = htons(__port); 
+        serverAddres.sin_port = htons(__port);
         serverAddres.sin_addr.s_addr = inet_addr(__address.c_str());
-        if(connect(_clientSocket, (sockaddr*)&serverAddres, sizeof(serverAddres)) == -1){
+        if (connect(_clientSocket, (sockaddr*)&serverAddres, sizeof(serverAddres)) == -1) {
             close(_clientSocket);
             throw std::runtime_error("[ERROR] FAILED CONNECT");
         }
     }
-    operator int() const{return _clientSocket;}
+    operator int() const { return _clientSocket; }
 };
-std::string readString(const SocketShell& __fd){
+std::string readString(const SocketShell& __fd) {
     char input[MESSAGE_SIZE] = "\0";
     int bytesRead = recv(__fd, input, MESSAGE_SIZE, 0);
-    if(bytesRead <= 0){
+    if (bytesRead <= 0) {
         throw std::runtime_error("[ERROR] FAILED READ");
     }
     return std::string(input);
 }
-void sendString(const SocketShell& __fd, const std::string& __buf){
+void sendString(const SocketShell& __fd, const std::string& __buf) {
     int bytesSend = send(__fd, __buf.c_str(), __buf.size(), 0);
-    if(bytesSend == -1){
+    if (bytesSend == -1) {
         throw std::runtime_error("[ERROR] FAILED SEND");
     }
 }
+
+#endif // _SOCKET_SHELL_H_

--- a/client.cpp
+++ b/client.cpp
@@ -49,13 +49,19 @@ int main(int argc, char** argv) {
 }
 
 void readFromServer(SocketShell clientSocket) {
-    while (!terminateReadFromServer.load()) {
-        std::string message = readString(clientSocket);
-        std::cout << CLEAR_LINE << message;
-        if (!buf.empty()) {
-            std::cout << buf;
-            std::cout.flush();
+    try {
+        while (!terminateReadFromServer.load()) {
+            std::string message = readString(clientSocket);
+            std::cout << CLEAR_LINE << message;
+            if (!buf.empty()) {
+                std::cout << buf;
+                std::cout.flush();
+            }
         }
+    }
+    catch (...) {
+        close(clientSocket);
+        return;
     }
 }
 bool handleAuthorization(SocketShell clientSocket, const int& preload_history) {

--- a/client.cpp
+++ b/client.cpp
@@ -5,16 +5,10 @@
 using json = nlohmann::json;
 
 std::string buf;
-void readFromServer(SocketShell clientSocket) {
-    while (true) {
-        std::string message = readString(clientSocket);
-        std::cout << CLEAR_LINE << message;
-        if (!buf.empty()) {
-            std::cout << buf;
-            std::cout.flush();
-        }
-    }
-}
+
+void readFromServer(SocketShell clientSocket);
+bool handleAuthorization(SocketShell clientSocket, const int& preload_history);
+
 int main(int argc, char** argv) {
     std::ifstream file("config.json");
     if (!file) {
@@ -27,18 +21,10 @@ int main(int argc, char** argv) {
     const int preload_history = config["preload_history"];
     try {
         SocketShell clientSocket(address, port);
-        while (true) {
-            std::cout << "login: ";
-            sendString(clientSocket, input());
-            std::cout << "password: ";
-            sendString(clientSocket, input("hidden"));
-            buf = readString(clientSocket);
-            if (buf == "accept") {
-                send(clientSocket, &preload_history, sizeof(int), 0);
-                break;
-            }
-            else { std::cout << buf << std::endl; }
-        }
+
+        bool authorized = handleAuthorization(clientSocket, preload_history);
+        if (!authorized) { return -1; }
+
         std::thread readThread(readFromServer, clientSocket);
         readThread.detach();
         while (true) {
@@ -55,4 +41,86 @@ int main(int argc, char** argv) {
         throw;
     }
     return 0;
+}
+
+void readFromServer(SocketShell clientSocket) {
+    while (true) {
+        std::string message = readString(clientSocket);
+        std::cout << CLEAR_LINE << message;
+        if (!buf.empty()) {
+            std::cout << buf;
+            std::cout.flush();
+        }
+    }
+}
+bool handleAuthorization(SocketShell clientSocket, const int& preload_history) {
+    // ASK IF USER IS ALREADY REGISTERED
+    std::cout << "Are you a new user? [y/n]: ";
+    std::string answer;
+    std::getline(std::cin, answer);
+    bool isNewUser = answer[0] == 'y' || answer[0] == 'Y';
+    bool isOldUser = answer[0] == 'n' || answer[0] == 'N';
+    while (!isNewUser && !isOldUser) {
+        std::cout << "Wrong answer, try again: ";
+        std::getline(std::cin, answer);
+        isNewUser = answer[0] == 'y' || answer[0] == 'Y';
+        isOldUser = answer[0] == 'n' || answer[0] == 'N';
+    }
+    // REGISTER NEW USER
+    if (isNewUser) {
+        // Get new user credentials
+        std::string newUserLogin;
+        std::string newUserPassword;
+        std::string newUserPasswordRepeat;
+
+        sendString(clientSocket, "new");
+
+        // get new user login
+        std::cout << "Your login: ";
+        sendString(clientSocket, input());
+
+        // get new user password
+        bool passwordsMatch = false;
+        do {
+            std::cout << "Your password: ";
+            newUserPassword = input("hidden");
+            std::cout << "Repeat your password: ";
+            newUserPasswordRepeat = input("hidden");
+
+            passwordsMatch = newUserPassword == newUserPasswordRepeat;
+            if (!passwordsMatch) {
+                std::cout << "Passwords do not match, try again" << std::endl;
+            }
+        } while (!passwordsMatch);
+
+        sendString(clientSocket, newUserPassword);
+
+        buf = readString(clientSocket);
+        bool isUserRegistered = buf == setColor("User successfully registered", { 0, 255, 0 });
+        if (isUserRegistered) {
+            send(clientSocket, &preload_history, sizeof(int), 0);
+            return true;
+        }
+        else {
+            std::cout << buf << std::endl;
+            return false;
+        }
+    }
+
+    // SIGN IN OLD USER
+    while (true) {
+        sendString(clientSocket, "old");
+        std::cout << "login: ";
+        sendString(clientSocket, input());
+        std::cout << "password: ";
+        sendString(clientSocket, input("hidden"));
+        buf = readString(clientSocket);
+        if (buf == "accept") {
+            send(clientSocket, &preload_history, sizeof(int), 0);
+            break;
+        }
+        else { std::cout << buf << std::endl; }
+    }
+
+    return true;
 }

--- a/client.cpp
+++ b/client.cpp
@@ -5,19 +5,19 @@
 using json = nlohmann::json;
 
 std::string buf;
-void readFromServer(SocketShell clientSocket){
-    while(true){
+void readFromServer(SocketShell clientSocket) {
+    while (true) {
         std::string message = readString(clientSocket);
         std::cout << CLEAR_LINE << message;
-        if(!buf.empty()){
+        if (!buf.empty()) {
             std::cout << buf;
             std::cout.flush();
         }
     }
 }
-int main(int argc, char** argv){
+int main(int argc, char** argv) {
     std::ifstream file("config.json");
-    if(!file){
+    if (!file) {
         std::cerr << "Cannot opening file" << std::endl;
         return -1;
     }
@@ -25,31 +25,32 @@ int main(int argc, char** argv){
     const std::string address = config["server_address"];
     const int port = config["port"];
     const int preload_history = config["preload_history"];
-    try{
+    try {
         SocketShell clientSocket(address, port);
-        while(true){
+        while (true) {
             std::cout << "login: ";
             sendString(clientSocket, input());
             std::cout << "password: ";
             sendString(clientSocket, input("hidden"));
             buf = readString(clientSocket);
-            if(buf == "accept"){
+            if (buf == "accept") {
                 send(clientSocket, &preload_history, sizeof(int), 0);
                 break;
             }
-            else{std::cout << buf << std::endl;}
+            else { std::cout << buf << std::endl; }
         }
         std::thread readThread(readFromServer, clientSocket);
         readThread.detach();
-        while(true){
+        while (true) {
             input(buf);
-            if(buf == "!q"){break;}
+            if (buf == "!q") { break; }
             std::cout << MOVE_UP;
-            if(validation(buf)){sendString(clientSocket, buf);}
-            else{std::cout << CLEAR_LINE << setColor("validation error", {255, 0, 0}) << ENDL;}
+            if (validation(buf)) { sendString(clientSocket, buf); }
+            else { std::cout << CLEAR_LINE << setColor("validation error", { 255, 0, 0 }) << ENDL; }
         }
         close(clientSocket);
-    }catch(std::exception& e){
+    }
+    catch (std::exception& e) {
         logging(e.what(), config["logging_path"]);
         throw;
     }

--- a/file_utils.h
+++ b/file_utils.h
@@ -11,6 +11,11 @@
 #include <ctime>
 #include <mutex>
 
+#ifdef __APPLE__
+#include <termios.h>
+#include <unistd.h>
+#endif
+
 #define BLINK "\x1B[5m"
 #define CLEAR_LINE "\r\x1B[K"
 #define MOVE_UP "\x1B[1A"

--- a/file_utils.h
+++ b/file_utils.h
@@ -1,4 +1,6 @@
-#pragma once
+#ifndef FILE_UTILS_H
+#define FILE_UTILS_H
+
 #include <iostream>
 #include <fstream>
 #include <iomanip>
@@ -16,71 +18,76 @@
 #define ENDL  "\r\n"
 
 std::mutex loggingMutex;
-void logging(const std::string& __message, const std::string& __path){
+void logging(const std::string& __message, const std::string& __path) {
     loggingMutex.lock();
     std::ofstream LOGFILE(__path, std::ios_base::app);
     std::time_t currentTime = std::time(nullptr);
-    std::tm *localTime = std::localtime(&currentTime);
-    if(LOGFILE.tellp() != 0){LOGFILE << std::endl;}
+    std::tm* localTime = std::localtime(&currentTime);
+    if (LOGFILE.tellp() != 0) { LOGFILE << std::endl; }
     LOGFILE << '['
-            << std::setfill('0') << std::setw(2) << localTime->tm_mday << '-'
-            << std::setfill('0') << std::setw(2) << localTime->tm_mon + 1 << '-'
-            << localTime->tm_year + 1900 << ' '
-            << std::setfill('0') << std::setw(2) << localTime->tm_hour << ':'
-            << std::setfill('0') << std::setw(2) << localTime->tm_min << ':'
-            << std::setfill('0') << std::setw(2) << localTime->tm_sec << "] "
-    << __message;
+        << std::setfill('0') << std::setw(2) << localTime->tm_mday << '-'
+        << std::setfill('0') << std::setw(2) << localTime->tm_mon + 1 << '-'
+        << localTime->tm_year + 1900 << ' '
+        << std::setfill('0') << std::setw(2) << localTime->tm_hour << ':'
+        << std::setfill('0') << std::setw(2) << localTime->tm_min << ':'
+        << std::setfill('0') << std::setw(2) << localTime->tm_sec << "] "
+        << __message;
     LOGFILE.close();
     loggingMutex.unlock();
 }
-bool validation(const std::string& __buf){
-    if(__buf.size() > 64){return false;}
-    if(!(__buf.back() == '.' || 
-       __buf.back() == '!' ||
-       __buf.back() == '?')){return false;}
-    for(const char& iter : __buf){
-        if(static_cast<int>(iter) < 32){
+bool validation(const std::string& __buf) {
+    if (__buf.size() > 64) { return false; }
+    if (!(__buf.back() == '.' ||
+        __buf.back() == '!' ||
+        __buf.back() == '?')) {
+        return false;
+    }
+    for (const char& iter : __buf) {
+        if (static_cast<int>(iter) < 32) {
             return false;
         }
     }
     return true;
 }
-void input(std::string& __buf, const char* __mode = "default"){
+void input(std::string& __buf, const char* __mode = "default") {
     char input = '\0';
     __buf.clear();
     system("stty raw");
-    while((input = std::cin.get()) != '\r'){
-        if(strcmp(__mode, "hidden") == 0){std::cerr << "\b*";}
-        if(input == '\177'){
+    while ((input = std::cin.get()) != '\r') {
+        if (strcmp(__mode, "hidden") == 0) { std::cerr << "\b*"; }
+        if (input == '\177') {
             std::cout << "\b\b  \b\b";
-            if(!__buf.empty()){
+            if (!__buf.empty()) {
                 std::cout << "\b \b";
                 __buf.pop_back();
             }
-        }else{__buf += input;}
+        }
+        else { __buf += input; }
     }
     system("stty cooked");
-    while(__buf.back() == ' '){__buf.pop_back();}
+    while (__buf.back() == ' ') { __buf.pop_back(); }
     std::cout << "\b\b  \b\b\r\n";
 }
-std::string input(const char* __mode = "default"){  
+std::string input(const char* __mode = "default") {
     std::string __buf;
     input(__buf, __mode);
     return __buf;
 }
-std::string setColor(const std::string& __buf, const std::vector<size_t>& __RGB = {0, 0, 0}){
-    size_t R = __RGB[0], 
-           G = __RGB[1],
-           B = __RGB[2];
+std::string setColor(const std::string& __buf, const std::vector<size_t>& __RGB = { 0, 0, 0 }) {
+    size_t R = __RGB[0],
+        G = __RGB[1],
+        B = __RGB[2];
     std::string color = "\x1B[38;2;" + std::to_string(R) + ';'
-                                     + std::to_string(G) + ';'
-                                     + std::to_string(B) + 'm'; 
+        + std::to_string(G) + ';'
+        + std::to_string(B) + 'm';
     return color + __buf + RESET;
 }
-std::string setColorRandom(const std::string& __buf){
+std::string setColorRandom(const std::string& __buf) {
     std::srand(std::time(nullptr));
-    size_t R = rand() % 256, 
-           G = rand() % 256,
-           B = rand() % 256;
-    return setColor(__buf, {R, G, B});
+    size_t R = rand() % 256,
+        G = rand() % 256,
+        B = rand() % 256;
+    return setColor(__buf, { R, G, B });
 }
+
+#endif // !FILE_UTILS_H

--- a/file_utils.h
+++ b/file_utils.h
@@ -146,5 +146,15 @@ std::string setColorRandom(const std::string& __buf) {
         B = rand() % 256;
     return setColor(__buf, { R, G, B });
 }
+std::string getLoginWithColor(const std::string& __login, std::map<std::string, std::vector<size_t>>& __colors) {
+    std::ifstream file("users.json");
+    if (!file) {
+        std::cerr << "Cannot open database file users.json" << std::endl;
+        return __login;
+    }
+    nlohmann::json users = nlohmann::json::parse(file);
+    file.close();
+    return setColor(__login, __colors[users[__login]["color"]]);
+}
 
 #endif // !FILE_UTILS_H

--- a/server.cpp
+++ b/server.cpp
@@ -6,28 +6,52 @@
 #define LOGGING_PATH "server.log"
 
 void clientHandler(SocketShell clientSocket) {
+    std::string new_or_old;
     std::string login;
     std::string password;
     while (true) {
         try {
+            new_or_old = readString(clientSocket);
             login = readString(clientSocket);
             password = readString(clientSocket);
+            logging("[INFO] HANDLING NEW CONNECTION", LOGGING_PATH);
+            logging("[INFO] USER INFO: [" + new_or_old + "]" + "[" + login + "]" + "[" + password + "]", LOGGING_PATH);
         }
         catch (...) {
             close(clientSocket);
             return;
         }
-        std::string cur_status = status(login, password);
-        sendString(clientSocket, cur_status);
-        if (cur_status == "accept") {
-            global::clientMutex.lock();
-            preload_history(clientSocket);
-            global::clients.push_back({ login, clientSocket });
-            global::clientMutex.unlock();
-            break;
+        if (new_or_old == "new") {
+            // Add new user to database
+            std::string register_status = registerUser(login, password);
+            if (register_status == "User successfully registered") {
+                sendString(clientSocket, setColor(register_status, { 0, 255, 0 }));
+                global::clientMutex.lock();
+                preload_history(clientSocket);
+                global::clients.push_back({ login, clientSocket });
+                global::clientMutex.unlock();
+                break;
+            }
+            else {
+                sendString(clientSocket, setColor(register_status, { 255, 0, 0 }));
+            }
+        }
+        else {
+            std::string cur_status = status(login, password);
+            sendString(clientSocket, cur_status);
+            if (cur_status == "accept") {
+                global::clientMutex.lock();
+                preload_history(clientSocket);
+                global::clients.push_back({ login, clientSocket });
+                global::clientMutex.unlock();
+                break;
+            }
         }
     }
-    login = setColorRandom(login);
+
+    // by this moment user is registered and added to database
+    login = getLoginWithColor(login, global::colors);
+
     sendClients(login + setColor(" connected", { 0, 255, 0 }));
     try {
         while (true) {
@@ -56,6 +80,9 @@ int main() {
         ServerSocket serverSocket(PORT);
         std::cout << "server start in port " << serverSocket.port() << std::endl;
         logging("[INFO] SERVER START IN PORT " + std::to_string(PORT), LOGGING_PATH);
+        logging("[INFO] INITIALIZING COLORS...", LOGGING_PATH);
+        initAssignedColorsWithDBFile();
+        logging("[INFO] ...COLORS INITIALIZED", LOGGING_PATH);
         while (true) {
             SocketShell clientSocket = serverSocket.acceptConnection();
             std::thread clientThread(clientHandler, clientSocket);

--- a/server.cpp
+++ b/server.cpp
@@ -5,57 +5,60 @@
 #define PORT 8080
 #define LOGGING_PATH "server.log"
 
-void clientHandler(SocketShell clientSocket){
+void clientHandler(SocketShell clientSocket) {
     std::string login;
     std::string password;
     int idx = -1;
-    while(true){
-        try{
+    while (true) {
+        try {
             login = readString(clientSocket);
             password = readString(clientSocket);
-        }catch(...){
+        }
+        catch (...) {
             close(clientSocket);
             return;
         }
         std::string cur_status = status(login, password);
         sendString(clientSocket, cur_status);
-        if(cur_status == "accept"){
+        if (cur_status == "accept") {
             global::clientMutex.lock();
             preload_history(clientSocket);
-            global::clients.push_back({login, clientSocket});
+            global::clients.push_back({ login, clientSocket });
             idx += global::clients.size();
             global::clientMutex.unlock();
             break;
         }
     }
     login = setColorRandom(login);
-    sendClients(login + setColor(" connected", {0, 255, 0}));
-    try{
-        while(true){
+    sendClients(login + setColor(" connected", { 0, 255, 0 }));
+    try {
+        while (true) {
             std::string message = readString(clientSocket);
             sendClients(login + ": " + message);
         }
-    }catch(...){
+    }
+    catch (...) {
         global::clientMutex.lock();
         close(clientSocket);
         global::clients.erase(global::clients.begin() + idx);
         global::clientMutex.unlock();
-        sendClients(login + setColor(" disconnected", {255, 0, 0}));
+        sendClients(login + setColor(" disconnected", { 255, 0, 0 }));
     }
 }
-int main(){
-    try{
+int main() {
+    try {
         ServerSocket serverSocket(PORT);
         std::cout << "server start in port " << serverSocket.port() << std::endl;
         logging("[INFO] SERVER START IN PORT " + std::to_string(PORT), LOGGING_PATH);
-        while(true){
+        while (true) {
             SocketShell clientSocket = serverSocket.acceptConnection();
             std::thread clientThread(clientHandler, clientSocket);
             clientThread.detach();
         }
-    } catch(std::exception& e){
+    }
+    catch (std::exception& e) {
         logging(e.what(), LOGGING_PATH);
         throw;
     }
     return 0;
-} 
+}

--- a/users.json
+++ b/users.json
@@ -1,6 +1,26 @@
-{   
-    "admin" : "admin",
-    "thedeepestreality" : "5y3k",
-    "spogozhev" : "uts7d",
-    "dav1dvorobev": "q8hp7"
+{
+    "admin": {
+        "color": "red",
+        "password": "admin"
+    },
+    "damikh": {
+        "color": "magenta",
+        "password": "lkm"
+    },
+    "dav1dvorobev": {
+        "color": "yellow",
+        "password": "q8hp7"
+    },
+    "spogozhev": {
+        "color": "green",
+        "password": "uts7d"
+    },
+    "thedeepestreality": {
+        "color": "orange",
+        "password": "5y3k"
+    },
+    "user1": {
+        "color": "bright pink",
+        "password": "pass"
+    }
 }

--- a/users.json
+++ b/users.json
@@ -3,10 +3,6 @@
         "color": "red",
         "password": "admin"
     },
-    "damikh": {
-        "color": "magenta",
-        "password": "lkm"
-    },
     "dav1dvorobev": {
         "color": "yellow",
         "password": "q8hp7"
@@ -18,9 +14,5 @@
     "thedeepestreality": {
         "color": "orange",
         "password": "5y3k"
-    },
-    "user1": {
-        "color": "bright pink",
-        "password": "pass"
     }
 }


### PR DESCRIPTION
### Изменения
Была добавлена регистрация, совмещённая с выбором цветов.
Изначально к каждому полю конкретного пользователя в `users.json` было добавлено доп. поле: `"color" : "red"`. Так что теперь пользователи выглядят так:
```json
{
"admin": {
        "color": "red",
        "password": "admin"
    }
}
```

При запуске клиента будет спрошено: `Are you a new user? [y/n]: <y/n>`

Если пользователь выбрал `n` (т.е. он уже зарегестрированный), его по-обычному спросят пароль и в дальнейшем он будет отображаться в чате в соответствии с цветом, определённом в `users.json`.

Если же пользователь выбрал `y`, то ему предоставится один из рандомных незанятых цветов (см. `ClientShell.h` -- `namespace global`). Так как цветовая палитра ограничена, то, если новый пользователь пытается зарегестрироваться в случае, когда все цвета уже были заняты, ему выдастся сообщение `All colors are used` и к чату он не подключится.

Из небольших изменений: 
- форматирование файлов с помощью prettier (+ пробелы, табуляции и т.д.)
- замена `#pragma once` на следующий формат (более клёвая практика, повышает переносимость и всё такое):
```cpp
#ifndef FILE_H
#define FILE_H
...
#endif
```
- добавлена доп. реализация функции input(), чтобы избежать ошибок с вводом (замена символов пароля на звёздочки и общее считывание инфы с терминала):
```cpp
#ifdef __APPLE__
<input implementation for MacOS terminal>
#else
<existing implementation for Ubuntu>
#endif
```
- добавлен флаг завершения потока функции `ReadFromServer` в `client.cpp`:
```cpp
#include <nlohmann/json.hpp>
...
std::atomic<bool> terminateReadFromServer(false);
...
int main(int argc, char** argv) {
...
            if (buf == "!q") {
                terminateReadFromServer.store(true); // so that readThread can exit
                break;
            }
...
}
...
void readFromServer(SocketShell clientSocket) {
    try {
        while (!terminateReadFromServer.load()) {
            std::string message = readString(clientSocket);
...
        }
    }
...
}
...
```
- в этой же функции -- `readFromServer` -- добавлена проверка `try ... catch ...`, чтобы избежать ошибки `libc++abi: terminating due to uncaught exception of type std::runtime_error: [ERROR] FAILED READ`, когда клиент отключается от чата при помощи `!q`
- изменено удаление клиентов на стороне сервера из списка подключённых клиентов с `global::clients.erase(global::clients.begin() + idx);` на следующее:
```cpp
        auto it = std::find_if(global::clients.begin(), global::clients.end(), [&](const ClientShell& client) {
            return client.clientSocket == clientSocket; // Directly compare each client's socket to the socket we're looking for
            });
        if (it != global::clients.end()) {
            global::clients.erase(it);
        }
```
При старом варианте на MacOS'и возникало исключение `[1]    73041 segmentation fault  ./server` при подключении двух клиентов и отключении первого и сервер просто падал. Так как новое удаление не требует переменной `idx`, то все её упоминания из кода были удалены.
### Рекоммендации (рецензия на код)
Я затрону только кодстайл, так как архитектура приложения выполнена отлично.
- чуть больше комментировать код
- чуть больше логгировать различные события
- использовать одинаковый принцип наименования переменных, функций, файлов и т.д.: или `varNum`, или `var_num`